### PR TITLE
Tests to demonstrate faulty eventDrop when rerendering during drag

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@fullcalendar/common": "~5.10.1",
     "@fullcalendar/interaction": "~5.10.1",
+    "fast-deep-equal": "^3.1.3",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@fullcalendar/common": "~5.10.1",
+    "@fullcalendar/interaction": "~5.10.1",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {

--- a/rollup.tests.js
+++ b/rollup.tests.js
@@ -8,7 +8,7 @@ import reactDom from 'react-dom'
 
 
 export default {
-  input: 'tests/main.jsx',
+  input: 'tests/index.jsx',
   output: {
     format: 'iife',
     file: 'tmp/tests.js',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import {
   CalendarApi, CalendarDataProvider,
   CalendarContent, CalendarRoot
 } from '@fullcalendar/common'
+import deepEqual from 'fast-deep-equal'
 
 
 export default class FullCalendar extends React.Component<CalendarOptions> {
@@ -32,6 +33,9 @@ export default class FullCalendar extends React.Component<CalendarOptions> {
     )
   }
 
+  shouldComponentUpdate(nextProps: Readonly<CalendarOptions>, nextState: Readonly<{}>, nextContext: any): boolean {
+    return !deepEqual(nextProps,this.props)
+  }
 
   getApi(): CalendarApi {
     return this._calendarApi

--- a/tests/event-drag.jsx
+++ b/tests/event-drag.jsx
@@ -1,0 +1,90 @@
+import React from 'react'
+import {render, cleanup, fireEvent, waitForElementToBeRemoved} from 'react-testing-library'
+import FullCalendar from '../dist/main'
+import daygridPlugin from '@fullcalendar/daygrid'
+import interactionPlugin from "@fullcalendar/interaction";
+
+const DEFAULT_OPTIONS = {
+  plugins: [daygridPlugin,interactionPlugin],
+  editable:true,
+  initialDate: '2017-02-09',
+  events: [{
+    title: 'Event 1',
+    start: '2017-02-09'
+  }]
+}
+
+
+// like, react-testing-library/cleanup-after-each, but doesn't double-import react-testing-library
+afterEach(() => cleanup())
+
+describe("Drag and drop on same calendar should call eventDrop and not eventReceive", ()=>{
+  it('without rerender', async function() {
+    let eventReceiveCallback = jasmine.createSpy('eventReceiveCallback')
+    let eventDropCallback = jasmine.createSpy('eventDropCallback')
+
+    let options = {
+      ...DEFAULT_OPTIONS,
+      eventDrop: eventDropCallback,
+      eventReceive: eventReceiveCallback,
+    }
+    let componentRef = React.createRef()
+    let { container, rerender } = render(
+      <FullCalendar {...options} ref={componentRef}/>
+    )
+
+    let element = getFirstEventEl(container)
+
+    // normal drag and drop in same calendar should call eventDrop callback
+    // and not eventReceive
+    fireEvent.mouseDown(element)
+    fireEvent.mouseMove(element, {clientX: -250})
+    fireEvent.mouseUp(element)
+
+    await waitForElementToBeRemoved(getDraggingEl)
+
+    expect(eventDropCallback).toHaveBeenCalled();
+    expect(eventReceiveCallback).not.toHaveBeenCalled();
+  })
+
+
+  it('with rerender during drag', async function() {
+    let eventReceiveCallback = jasmine.createSpy('eventReceiveCallback')
+    let eventDropCallback = jasmine.createSpy('eventDropCallback')
+
+    let options = {
+      ...DEFAULT_OPTIONS,
+      eventDrop: eventDropCallback,
+      eventReceive: eventReceiveCallback,
+    }
+    let componentRef = React.createRef()
+    let { container, rerender } = render(
+      <FullCalendar {...options} ref={componentRef}/>
+    )
+
+    let element = getFirstEventEl(container)
+
+    // when rerendering the fullcalendar component with the same props during a
+    // drag operation also eventDrop and not eventReceive should be called
+    // this can be triggered by any wrapping component and should work seamlessly
+    fireEvent.mouseDown(element)
+    fireEvent.mouseMove(element, {clientX: -250})
+    rerender(
+      <FullCalendar {...options} ref={componentRef}/>
+    )
+    fireEvent.mouseUp(element)
+
+    await waitForElementToBeRemoved(getDraggingEl)
+
+    expect(eventDropCallback).toHaveBeenCalled();
+    expect(eventReceiveCallback).not.toHaveBeenCalled();
+  })
+})
+
+function getDraggingEl(container) {
+  return document.querySelector(".fc-event-dragging")
+}
+
+function getFirstEventEl(container) {
+  return container.querySelector('.fc-event')
+}

--- a/tests/index.jsx
+++ b/tests/index.jsx
@@ -1,0 +1,2 @@
+import './main.jsx'
+import './event-drag.jsx'


### PR DESCRIPTION
Hello,

this is a test that should demonstrate the bug fullcalendar/fullcalendar#6747 .
1. It renders a FullCalendar with react plugin 
2. Then it simulates a drag event
3. When a rerender is called during drag and before drop, eventReceive is called instead of eventDrop
4. It also adds a test without rerender, which works a expected 

To run, it yourself
1. checkout
2. npm install
3. npm run test:watch

<img width="1049" alt="image" src="https://user-images.githubusercontent.com/68172/160256776-197bdbff-be00-4519-bbbb-0ad94b72d860.png">

Next step would be to fix this behaviour. 
