### PR TITLE
Bump fullcalendar/common to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ci": "./scripts/ci.sh"
   },
   "dependencies": {
-    "@fullcalendar/common": "~5.11.2",
+    "@fullcalendar/common": "~5.11.3",
     "tslib": "^2.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
It looks like `@fullcalendar/common` has been increased to 5.11.3.
When trying to include a plugin (such as resource-timeline), the typescript compilation fails. 
Inspecting a yarn.lock file, show that the plugin, and the react libraries are using different version of `@fullcalendar/common`